### PR TITLE
Automatically detect number of cores for make

### DIFF
--- a/mnt/build_kernel.sh
+++ b/mnt/build_kernel.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CORES=4
+CORES=`nproc`
 ROOTFS=/mnt/boot
 git clone --depth 1 -b JH7110_VisionFive2_devel https://github.com/starfive-tech/linux.git
 cd linux


### PR DESCRIPTION
Instead of hard coding the build script to 4 cores, this change uses the nproc command to determine the number of cores available and uses all of them to build. This makes a huge difference to build times as the number of available cores increases.